### PR TITLE
Remove dependency on custom fork of python-datetime-tz

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-https://github.com/st-james-software/python-datetime-tz/archive/v0.2-j5p1.zip#egg=python-datetime-tz-0.2-j5p1
+python-datetime-tz>=0.5
 nose
 decorator

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='virtualtime',
-    version='1.3',
+    version='1.4',
     packages=['virtualtime', 'virtualtime.datetime_tz'],
     license='Apache License, Version 2.0',
     description='Implements a system for simulating a virtual time.',
@@ -21,9 +21,8 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Software Development :: Testing',
     ],
-    install_requires = ['python-datetime-tz == 0.2-j5p1'],
+    install_requires = ['python-datetime-tz >= 0.5'],
     extras_require = {
         'tests':  ["nose", 'decorator'],
         },
-    dependency_links = ["https://github.com/st-james-software/python-datetime-tz/archive/v0.2-j5p1.zip#egg=python-datetime-tz-0.2-j5p1"]
 )

--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,9 @@ setup(
     license='Apache License, Version 2.0',
     description='Implements a system for simulating a virtual time.',
     long_description=open('README.md').read(),
-    url='http://www.sjsoft.com/',
-    author='St James Software',
-    author_email='support@sjsoft.com',
+    url='http://www.j5int.com/',
+    author='j5 International',
+    author_email='support@j5int.com',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'License :: OSI Approved :: Apache Software License',


### PR DESCRIPTION
The custom fork of python-datetime-tz is no longer required - the changes that are needed have been merged in to version 0.5.
