### PR TITLE
Make time.strftime and datetime.datetime.strftime handle dates pre-1900

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,10 @@ This also includes an extension to the python-datetime-tz library (`datetime_tz`
 classes are all patched in the correct order. It also changes the behaviour of `datetime_tz.datetime_tz` objects
 to allow them to be compared with naive `datetime.datetime` objects by assuming that they are in the local timezone, if unspecified.
 
+This always patches `time.strftime` and `datetime.datetime.strftime` to support pre-1900 and pre-1000 years
+and to not map years between `0` and `99` to the years `1969` to `2068`, on versions prior to Python 3.3
+(where all years are supported without any strange mapping), even when `virtualtime` is not enabled.
+See http://bugs.python.org/issue1777412 for a discussion on the Python 2.7 behaviour
+
 This library is licensed under the Apache License, Version 2.0, and is published on pypi at
 https://pypi.python.org/pypi/virtualtime

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='virtualtime',
-    version='1.4',
+    version='1.5',
     packages=['virtualtime', 'virtualtime.datetime_tz'],
     license='Apache License, Version 2.0',
     description='Implements a system for simulating a virtual time.',

--- a/virtualtime/__init__.py
+++ b/virtualtime/__init__.py
@@ -64,8 +64,8 @@ def _repair_year(s1, s2, y1, y2, year):
         if f == -1:
             break
         if s2[f:f+4] != ys2:
-            t += s1[i:f+4]
-            i = f + 4
+            t += s1[i:f+1]
+            i = f + 1
             continue
         t += s1[i:f] + ys
         i = f + 4

--- a/virtualtime/datetime_tz/test_datetime_tz.py
+++ b/virtualtime/datetime_tz/test_datetime_tz.py
@@ -71,14 +71,14 @@ class TestDST():
         datetime.datetime.localtz_override = pytz.timezone("America/Chicago")
         exc = pytz.NonExistentTimeError
 
-        assert self.runTest(datetime_tz.datetime_tz, exc, True, 2014, 03, 9, 1, 10, 0, 0)
-        assert self.runTest(datetime_tz.localize, exc, True, datetime.datetime(2014, 03, 9, 1, 10, 0, 0))
+        assert self.runTest(datetime_tz.datetime_tz, exc, True, 2014, 3, 9, 1, 10, 0, 0)
+        assert self.runTest(datetime_tz.localize, exc, True, datetime.datetime(2014, 3, 9, 1, 10, 0, 0))
 
-        assert self.runTest(datetime_tz.datetime_tz, exc, False, 2014, 03, 9, 2, 10, 0, 0)
-        assert self.runTest(datetime_tz.localize, exc, False, datetime.datetime(2014, 03, 9, 2, 10, 0, 0))
+        assert self.runTest(datetime_tz.datetime_tz, exc, False, 2014, 3, 9, 2, 10, 0, 0)
+        assert self.runTest(datetime_tz.localize, exc, False, datetime.datetime(2014, 3, 9, 2, 10, 0, 0))
 
-        assert self.runTest(datetime_tz.datetime_tz, exc, True, 2014, 03, 9, 3, 10, 0, 0)
-        assert self.runTest(datetime_tz.localize, exc, True, datetime.datetime(2014, 03, 9, 3, 10, 0, 0))
+        assert self.runTest(datetime_tz.datetime_tz, exc, True, 2014, 3, 9, 3, 10, 0, 0)
+        assert self.runTest(datetime_tz.localize, exc, True, datetime.datetime(2014, 3, 9, 3, 10, 0, 0))
 
 
     def test_DST_ambiguous_hour(self):

--- a/virtualtime/test_virtualtime.py
+++ b/virtualtime/test_virtualtime.py
@@ -190,6 +190,24 @@ class RealTimeBase(object):
         """tests that real time is still happening in the datetime_tz module"""
         check_real_time_function(datetime_tz.datetime_tz.utcnow, "virtualtime.datetime_tz.datetime_tz.utcnow()", "virtualtime.datetime_tz")
 
+    def test_strftime_pre_1900(self):
+        """tests that we can strftime on times before 1900 (patching 2.7 bug)"""
+        # half way through the cannons, on the battle day
+        overture_date = datetime_tz.datetime_tz(1812, 9, 10, 12, 7, 30, tzinfo=pytz.timezone("Europe/Moscow"))
+        overture_datestr = overture_date.strftime("%Y-%m-%d %H:%M:%S+%Z")
+        assert overture_datestr == "1812-09-10 12:07:30+MSK"
+        overture_timetuple = overture_date.utctimetuple()
+        overture_timestr = time.strftime("%Y-%m-%d %H:%M:%S", overture_timetuple)
+        assert overture_timestr == "1812-09-10 09:37:30"
+        # also test after 1900 to make sure that's as before
+        renzetti_date = overture_date.replace(year=1912)
+        renzetti_datestr = renzetti_date.strftime("%Y-%m-%d %H:%M:%S+%Z")
+        assert renzetti_datestr == "1912-09-10 12:07:30+MMT"
+        renzetti_timetuple = renzetti_date.utctimetuple()
+        renzetti_timestr = time.strftime("%Y-%m-%d %H:%M:%S", renzetti_timetuple)
+        assert renzetti_timestr == "1912-09-10 09:37:30"
+
+
 class TestUnpatchedRealTime(RealTimeBase, RunUnpatched):
     """Tests for real time functions when virtualtime is disabled"""
 

--- a/virtualtime/test_virtualtime.py
+++ b/virtualtime/test_virtualtime.py
@@ -703,13 +703,13 @@ class TestVirtualDatetimeOffset:
 
     def test_offset(self):
         """Make sure the offset is correct when using the localtz override"""
-        localdatetime = datetime.datetime(2014,03,9,1,45,0)
+        localdatetime = datetime.datetime(2014,3,9,1,45,0)
         virtualtime.set_local_datetime(localdatetime)
         self.runTests(localdatetime)
-        localdatetime = datetime.datetime(2014,03,9,2,45,0)
+        localdatetime = datetime.datetime(2014,3,9,2,45,0)
         virtualtime.set_local_datetime(localdatetime)
         self.runTests(localdatetime)
-        localdatetime = datetime.datetime(2014,03,9,3,45,0)
+        localdatetime = datetime.datetime(2014,3,9,3,45,0)
         virtualtime.set_local_datetime(localdatetime)
         self.runTests(localdatetime)
         localdatetime = datetime.datetime(2014,11,2,0,45,0)
@@ -726,16 +726,16 @@ class TestVirtualDatetimeOffset:
 
     def runTests(self,localdatetime):
         tz = datetime.datetime.localtz_override
-        print "now"
+        print ("now")
         assert self.close_enough(datetime.datetime.now(), localdatetime)
         utcnow = datetime_tz.datetime_tz.utcnow()
-        print "utcnow"
+        print ("utcnow")
         assert self.close_enough(utcnow, tz.localize(localdatetime))
         now = datetime_tz.datetime_tz.now()
-        print "_tznow"
+        print ("_tznow")
         assert self.close_enough(now, tz.localize(localdatetime))
 
     def close_enough(self,dt,dt1):
-        print dt,"\t", dt1
+        print (dt,"\t", dt1)
         return (dt - dt1) < datetime.timedelta(seconds=1)
 

--- a/virtualtime/test_virtualtime.py
+++ b/virtualtime/test_virtualtime.py
@@ -207,6 +207,15 @@ class RealTimeBase(object):
         renzetti_timestr = time.strftime("%Y-%m-%d %H:%M:%S", renzetti_timetuple)
         assert renzetti_timestr == "1912-09-10 09:37:30"
 
+    def test_repair_year(self):
+        assert virtualtime._repair_year("2014-01-02 15:13:56", "2414-01-02 15:13:56", 2014, 2414, 14) == \
+               "14-01-02 15:13:56"
+        assert virtualtime._repair_year("2214-14-22 14:26:56.22141420", "2614-14-22 14:26:56.22141420", 2214, 2614, 1414) == \
+               "1414-14-22 14:26:56.22141420"
+        assert virtualtime._repair_year("2004-14-22 14:26:56.22141420", "2404-14-22 14:26:56.22141420", 2004, 2404, 4) == \
+               "4-14-22 14:26:56.22141420"
+
+
 
 class TestUnpatchedRealTime(RealTimeBase, RunUnpatched):
     """Tests for real time functions when virtualtime is disabled"""

--- a/virtualtime/test_virtualtime.py
+++ b/virtualtime/test_virtualtime.py
@@ -219,6 +219,20 @@ class RealTimeBase(object):
         ordono_timetuple = ordono_date.utctimetuple()
         ordono_timestr = time.strftime("%Y-%m-%d %H:%M:%S", ordono_timetuple)
         assert ordono_timestr == "912-09-10 09:37:30"
+        # just for fun, and to ensure year matching doesn't match the wrong stuff
+        repetitive_date = datetime_tz.datetime_tz(1111,11,11,11,11,11, tzinfo=pytz.UTC)
+        repetitive_datestr = repetitive_date.strftime("%d%Y%m%H%Y%M%S1%Y1%y")
+        assert repetitive_datestr == "11111111111111111111111111"
+        repetitive_timetuple = repetitive_date.utctimetuple()
+        repetitive_timestr = time.strftime("1%Y1%d%m%H%Y%M%S%Y%y", repetitive_timetuple)
+        assert repetitive_timestr == "11111111111111111111111111"
+        # broken with 4-char skip
+        broken_date = datetime_tz.datetime_tz(1119,11,19)
+        broken_datestr = broken_date.strftime("%d%Y")
+        assert broken_datestr == "191119"
+        broken_timetuple = broken_date.utctimetuple()
+        broken_timestr = time.strftime("%y%Y", broken_timetuple)
+        assert broken_timestr == "191119"
 
     def test_repair_year(self):
         assert virtualtime._repair_year("2014-01-02 15:13:56", "2414-01-02 15:13:56", 2014, 2414, 14) == \

--- a/virtualtime/test_virtualtime.py
+++ b/virtualtime/test_virtualtime.py
@@ -206,6 +206,19 @@ class RealTimeBase(object):
         renzetti_timetuple = renzetti_date.utctimetuple()
         renzetti_timestr = time.strftime("%Y-%m-%d %H:%M:%S", renzetti_timetuple)
         assert renzetti_timestr == "1912-09-10 09:37:30"
+        # and let's handle the 0-99 and 100-999 cases that are different on different python versions
+        rufus_date = overture_date.replace(year=12)
+        rufus_datestr = rufus_date.strftime("%Y-%m-%d %H:%M:%S+%Z")
+        assert rufus_datestr == "12-09-10 12:07:30+MSK"
+        rufus_timetuple = rufus_date.utctimetuple()
+        rufus_timestr = time.strftime("%Y-%m-%d %H:%M:%S", rufus_timetuple)
+        assert rufus_timestr == "12-09-10 09:37:30"
+        ordono_date = overture_date.replace(year=912)
+        ordono_datestr = ordono_date.strftime("%Y-%m-%d %H:%M:%S+%Z")
+        assert ordono_datestr == "912-09-10 12:07:30+MSK"
+        ordono_timetuple = ordono_date.utctimetuple()
+        ordono_timestr = time.strftime("%Y-%m-%d %H:%M:%S", ordono_timetuple)
+        assert ordono_timestr == "912-09-10 09:37:30"
 
     def test_repair_year(self):
         assert virtualtime._repair_year("2014-01-02 15:13:56", "2414-01-02 15:13:56", 2014, 2414, 14) == \


### PR DESCRIPTION
*Main problem*: Python 2.7 and before doesn't support strftime on dates with year pre-1900 (either in `time.strftime` or in `datetime.datetime.strftime`), simply raising an error about the year being out of range, to try and avoid problems on certain platforms

*In addition*, `time.strftime` rather interestingly interprets `0 <= year < 100` to be around the year 2000, with `0 <= year < 68` being mapped to `2000 + year`, and `69 <= year < 100` being mapped to `1900 + year`.

* This has been fixed on Python 3.2 to support dates from 1000 upwards, but retain the `0 <= year < 100` behavior.
* It has been fixed on Python 3.4 to support dates from 0 upwards, without the interesting `0 <= year < 100` behavior.

The non-support of old dates in `strftime` means that if erroneous dates sneak into data, errors occur in unhelpful places. Also, if actually wanting to deal with old dates, then problems occur at format time, which is not that pleasant.

This patch adjusts the behaviour on Python interpreters not supporting dates pre-`1900` or pre-`1000` to support dates from 1 AD onwards in `datetime.datetime.strftime` and `time.strftime`. Additionally, the interpretation of years is adjusted to not compensate for `0 <= year < 100`. The patch is applied whether `virtualtime` is enabled or not.

This seems sensible to include in `virtualtime` as I can't imagine who would desire the erroneous behaviour, and it has all the mechanisms for patching already.