### PR TITLE
Try and import pandas, if present, before patching datetime

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='virtualtime',
-    version='1.5',
+    version='1.6',
     packages=['virtualtime', 'virtualtime.datetime_tz'],
     license='Apache License, Version 2.0',
     description='Implements a system for simulating a virtual time.',

--- a/virtualtime/__init__.py
+++ b/virtualtime/__init__.py
@@ -29,13 +29,8 @@ except ImportError as e:
       def wraps(f, *args, **kw):
           return f
 
-# Try and import numpy and pandas before patching datetime, else they get upset
+# Try and import pandas before patching datetime, else it gets upset
 # Import errors are ignored so that this is safe to do when they are not present
-
-try:
-    import numpy
-except ImportError as e:
-    pass
 
 try:
     import pandas

--- a/virtualtime/__init__.py
+++ b/virtualtime/__init__.py
@@ -29,6 +29,19 @@ except ImportError as e:
       def wraps(f, *args, **kw):
           return f
 
+# Try and import numpy and pandas before patching datetime, else they get upset
+# Import errors are ignored so that this is safe to do when they are not present
+
+try:
+    import numpy
+except ImportError as e:
+    pass
+
+try:
+    import pandas
+except ImportError as e:
+    pass
+
 TIME_CHANGE_LOG_LEVEL = logging.CRITICAL
 MAX_CALLBACK_TIME = 1.0
 MAX_DELAY_TIME = 60.0


### PR DESCRIPTION
Otherwise they get upset.

This may seem like a strange place to fix this problem, bit numpy and pandas are pretty common libraries, so I think it is best for virtualtime to play as well as it can with them.