### PR TITLE
Make tzinfo parameter of astimezone optional

### DIFF
--- a/virtualtime/__init__.py
+++ b/virtualtime/__init__.py
@@ -244,8 +244,8 @@ class datetime(_original_datetime_module.datetime):
     if _has_pre_1900_bug or _has_pre_1000_bug:
         strftime = _fixed_strftime
 
-    def astimezone(self, tzinfo):
-        d = _underlying_datetime_type.astimezone(self, tzinfo)
+    def astimezone(self, tz=None):
+        d = _underlying_datetime_type.astimezone(self, tz)
         return _original_datetime_type.__new__(type(self), d)
     astimezone.__doc__ = _underlying_datetime_type.astimezone.__doc__
 


### PR DESCRIPTION
The tzinfo parameter is optional in Python 3.

Compare:

https://docs.python.org/2.7/library/datetime.html#datetime.datetime.astimezone

with

https://docs.python.org/3/library/datetime.html#datetime.datetime.astimezone

This change is necessary because the builtin python function
email.utils.formatdate calls astimezone without any arguments.