### PR TITLE
Fix: unhashable type datetime_tz on python3 by removing mixed type comparison feature

### DIFF
--- a/virtualtime/datetime_tz/__init__.py
+++ b/virtualtime/datetime_tz/__init__.py
@@ -8,51 +8,59 @@ assert issubclass(base_datetime_tz.datetime_tz, patched_datetime_type), 'The bas
 
 from datetime_tz import detect_timezone, iterate, localtz
 from datetime_tz import localtz_set, timedelta, get_naive, localtz_name, require_timezone
+import sys
 
-class datetime_tz(base_datetime_tz.datetime_tz):
+PY2 = sys.version_info[0] == 2
 
-  def __eq__(self, other):
-    if isinstance(other, patched_datetime_type) and other.tzinfo is None:
-        other = localize(other)
-    return super(datetime_tz, self).__eq__(other)
+if PY2:
+    #These mixed type comparison features were misguided and we have removed support for them in PY3 (where comparisons in general are stricter)
+    class datetime_tz(base_datetime_tz.datetime_tz):
 
-  def __gt__(self, other):
-    if isinstance(other, patched_datetime_type) and other.tzinfo is None:
-        other = localize(other)
-    return super(datetime_tz, self).__gt__(other)
+      def __eq__(self, other):
+        if isinstance(other, patched_datetime_type) and other.tzinfo is None:
+            other = localize(other)
+        return super(datetime_tz, self).__eq__(other)
 
-  def __ge__(self, other):
-    if isinstance(other, patched_datetime_type) and other.tzinfo is None:
-        other = localize(other)
-    return super(datetime_tz, self).__ge__(other)
+      def __gt__(self, other):
+        if isinstance(other, patched_datetime_type) and other.tzinfo is None:
+            other = localize(other)
+        return super(datetime_tz, self).__gt__(other)
 
-  def __lt__(self, other):
-    if isinstance(other, patched_datetime_type) and other.tzinfo is None:
-        other = localize(other)
-    return super(datetime_tz, self).__lt__(other)
+      def __ge__(self, other):
+        if isinstance(other, patched_datetime_type) and other.tzinfo is None:
+            other = localize(other)
+        return super(datetime_tz, self).__ge__(other)
 
-  def __le__(self, other):
-    if isinstance(other, patched_datetime_type) and other.tzinfo is None:
-        other = localize(other)
-    return super(datetime_tz, self).__le__(other)
+      def __lt__(self, other):
+        if isinstance(other, patched_datetime_type) and other.tzinfo is None:
+            other = localize(other)
+        return super(datetime_tz, self).__lt__(other)
 
-  def __ne__(self, other):
-    if isinstance(other, patched_datetime_type) and other.tzinfo is None:
-        other = localize(other)
-    return super(datetime_tz, self).__ne__(other)
+      def __le__(self, other):
+        if isinstance(other, patched_datetime_type) and other.tzinfo is None:
+            other = localize(other)
+        return super(datetime_tz, self).__le__(other)
 
-def localize(dt, force_to_local=True):
-    """Localize a datetime to the local timezone
+      def __ne__(self, other):
+        if isinstance(other, patched_datetime_type) and other.tzinfo is None:
+            other = localize(other)
+        return super(datetime_tz, self).__ne__(other)
 
-    If dt is naive, returns the same datetime with the local timezone
-    Else, uses astimezone to convert"""
-    dt = base_datetime_tz.localize(dt, force_to_local)
-    if isinstance(dt, base_datetime_tz.datetime_tz) and not isinstance(dt, datetime_tz):
-        dt = datetime_tz(dt)
-    return dt
+    def localize(dt, force_to_local=True):
+        """Localize a datetime to the local timezone
 
-datetime_tz.min = datetime_tz(base_datetime_tz.datetime_tz.min)
-datetime_tz.max = datetime_tz(base_datetime_tz.datetime_tz.max)
+        If dt is naive, returns the same datetime with the local timezone
+        Else, uses astimezone to convert"""
+        dt = base_datetime_tz.localize(dt, force_to_local)
+        if isinstance(dt, base_datetime_tz.datetime_tz) and not isinstance(dt, datetime_tz):
+            dt = datetime_tz(dt)
+        return dt
+
+    datetime_tz.min = datetime_tz(base_datetime_tz.datetime_tz.min)
+    datetime_tz.max = datetime_tz(base_datetime_tz.datetime_tz.max)
+else:
+    datetime_tz = base_datetime_tz.datetime_tz
+    localize = base_datetime_tz.localize
 
 __all__ = ['datetime_tz', 'base_datetime_tz', 'detect_timezone', 'iterate', 'localtz',
     'localtz_set', 'localtz_name', 'timedelta', 'get_naive', 'require_timezone', 'localize']

--- a/virtualtime/datetime_tz/__init__.py
+++ b/virtualtime/datetime_tz/__init__.py
@@ -11,9 +11,6 @@ from datetime_tz import localtz_set, timedelta, get_naive, localtz_name, require
 
 class datetime_tz(base_datetime_tz.datetime_tz):
 
-  def __hash__(self):
-    return super(datetime_tz, self).__hash__()
-
   def __eq__(self, other):
     if isinstance(other, patched_datetime_type) and other.tzinfo is None:
         other = localize(other)

--- a/virtualtime/datetime_tz/__init__.py
+++ b/virtualtime/datetime_tz/__init__.py
@@ -11,6 +11,9 @@ from datetime_tz import localtz_set, timedelta, get_naive, localtz_name, require
 
 class datetime_tz(base_datetime_tz.datetime_tz):
 
+  def __hash__(self):
+    return super(datetime_tz, self).__hash__()
+
   def __eq__(self, other):
     if isinstance(other, patched_datetime_type) and other.tzinfo is None:
         other = localize(other)

--- a/virtualtime/datetime_tz/test_datetime_tz.py
+++ b/virtualtime/datetime_tz/test_datetime_tz.py
@@ -3,6 +3,7 @@
 from virtualtime import datetime_tz
 import datetime
 import pytz
+from virtualtime.datetime_tz import PY2, localize
 
 def test_type_of_now_makes_sense():
     n = datetime_tz.datetime_tz.now()
@@ -10,29 +11,41 @@ def test_type_of_now_makes_sense():
 
 def test_compare_tz_first():
     a = datetime.datetime(2012,3,4,1,2,3)
+    if not PY2:
+        a = localize(a)
     b = datetime_tz.datetime_tz(2012,3,4,1,2,3)
     assert a == b
 
 def test_compare_tz_second():
     a = datetime.datetime(2012,3,4,1,2,3)
+    if not PY2:
+        a = localize(a)
     b = datetime_tz.datetime_tz(2012,3,4,1,2,3)
     assert b == a
 
 def test_compare_greater():
     a = datetime.datetime(2012,3,4,3,2,3)
+    if not PY2:
+        a = localize(a)
     b = datetime_tz.datetime_tz(2012,3,4,1,2,3)
     assert a > b
     assert a >= b
     a = datetime.datetime(2012,3,3,3,2,3)
+    if not PY2:
+        a = localize(a)
     assert b > a
     assert b >= a
 
 def test_compare_less():
     a = datetime.datetime(2012,3,4,3,2,3)
+    if not PY2:
+        a = localize(a)
     b = datetime_tz.datetime_tz(2012,3,4,1,2,3)
     assert b < a
     assert b <= a
     a = datetime.datetime(2012,3,3,3,2,3)
+    if not PY2:
+        a = localize(a)
     assert a < b
     assert a <= b
 


### PR DESCRIPTION
On Python3 if you implement the `__eq__` function you should also implement the `__hash__` function, otherwise you end up with an unhashable type. 

On reflection, we have looked a bit deeper at the functionality that we have here that allows comparison between datetime_tz objects and naive datetime objects by just hoping that they are in local time.

We believe that this was misguided, and likely to cause trouble. It also put us in a slightly untenable situation in trying to figure out how to implement the `__hash__` function in a way that would not break some key invariant on the comparitors. For those two reasons, we've decided to simply remove this capability on PY3. Python3 is a lot stricter about comparing mixed types, so I think this is in the spirit of the activities required for update anyway.

We will keep the capability on py2, though.