### PR TITLE
Really trap import locks, and add workarounds to avoid them and tests

### DIFF
--- a/virtualtime/__init__.py
+++ b/virtualtime/__init__.py
@@ -261,8 +261,17 @@ class date(_original_datetime_module.date):
             yday = self.toordinal() - datetime_module.date(self.year, 1, 1).toordinal() + 1
             return (self.year, self.month, self.day, 0, 0, 0, self.weekday(), yday, -1)
 
+    def strftime(self, format_str):
+        """Adjusted version of datetime's strftime that handles dates before 1900 or 1000, if python's is broken"""
+        # Also handles ImportErrors if the datetime module produces them, falling back to the time.strftime implementation
+        try:
+            return _underlying_date_type.strftime(self, format_str)
+        except ImportError:
+            yday = self.toordinal() - datetime_module.date(self.year, 1, 1).toordinal() + 1
+            return _underlying_strftime(format_str, (self.year, self.month, self.day, 0, 0, 0, self.weekday(), yday, -1))
+
 # this time class doesn't actually adjust times to reflect the virtual time offset, but does prevent ImportErrors
-class time_no_importerror(_original_datetime_module.date):
+class time_no_importerror(_original_datetime_module.time):
     def strftime(self, format_str):
         """Adjusted version of datetime's strftime that handles dates before 1900 or 1000, if python's is broken"""
         # Also handles ImportErrors if the datetime module produces them, falling back to the time.strftime implementation
@@ -270,7 +279,7 @@ class time_no_importerror(_original_datetime_module.date):
             return _underlying_time_type.strftime(self, format_str)
         except ImportError:
             # copy what datetimemodule.c does to produce a time tuple with standard date
-            return _underlying_strftime(format_str, (1900, 1, 1, self.hour, self.minute, self.second, 0, 1, 1))
+            return _underlying_strftime(format_str, (1900, 1, 1, self.hour, self.minute, self.second, 0, 1, -1))
 
 _virtual_datetime_attrs = dict(_underlying_datetime_type.__dict__.items())
 class datetime(_original_datetime_module.datetime):

--- a/virtualtime/__init__.py
+++ b/virtualtime/__init__.py
@@ -261,6 +261,17 @@ class date(_original_datetime_module.date):
             yday = self.toordinal() - datetime_module.date(self.year, 1, 1).toordinal() + 1
             return (self.year, self.month, self.day, 0, 0, 0, self.weekday(), yday, -1)
 
+# this time class doesn't actually adjust times to reflect the virtual time offset, but does prevent ImportErrors
+class time_no_importerror(_original_datetime_module.date):
+    def strftime(self, format_str):
+        """Adjusted version of datetime's strftime that handles dates before 1900 or 1000, if python's is broken"""
+        # Also handles ImportErrors if the datetime module produces them, falling back to the time.strftime implementation
+        try:
+            return _underlying_time_type.strftime(self, format_str)
+        except ImportError:
+            # copy what datetimemodule.c does to produce a time tuple with standard date
+            return _underlying_strftime(format_str, (1900, 1, 1, self.hour, self.minute, self.second, 0, 1, 1))
+
 _virtual_datetime_attrs = dict(_underlying_datetime_type.__dict__.items())
 class datetime(_original_datetime_module.datetime):
     def __new__(cls, *args, **kwargs):

--- a/virtualtime/__init__.py
+++ b/virtualtime/__init__.py
@@ -232,7 +232,8 @@ _underlying_date_type = _original_datetime_module.date
 _underlying_time_type = _original_datetime_module.time
 
 # this date class doesn't actually adjust dates to reflect the virtual time offset, but does prevent ImportErrors
-class date(_original_datetime_module.date):
+# we don't patch this at present
+class date_no_importerror(_original_datetime_module.date):
     def __new__(cls, *args, **kwargs):
         if args and isinstance(args[0], _underlying_date_type):
             dt = args[0]
@@ -272,6 +273,7 @@ class date(_original_datetime_module.date):
             return _underlying_strftime(format_str, (self.year, self.month, self.day, 0, 0, 0, self.weekday(), yday, -1))
 
 # this time class doesn't actually adjust times to reflect the virtual time offset, but does prevent ImportErrors
+# we don't patch this at present
 class time_no_importerror(_original_datetime_module.time):
     def strftime(self, format_str):
         """Adjusted version of datetime's strftime that handles dates before 1900 or 1000, if python's is broken"""

--- a/virtualtime/__init__.py
+++ b/virtualtime/__init__.py
@@ -268,6 +268,7 @@ class date(_original_datetime_module.date):
             return _underlying_date_type.strftime(self, format_str)
         except ImportError:
             yday = self.toordinal() - datetime_module.date(self.year, 1, 1).toordinal() + 1
+            format_str = alt_time_funcs.adjust_strftime(self, format_str)
             return _underlying_strftime(format_str, (self.year, self.month, self.day, 0, 0, 0, self.weekday(), yday, -1))
 
 # this time class doesn't actually adjust times to reflect the virtual time offset, but does prevent ImportErrors
@@ -278,6 +279,7 @@ class time_no_importerror(_original_datetime_module.time):
         try:
             return _underlying_time_type.strftime(self, format_str)
         except ImportError:
+            format_str = alt_time_funcs.adjust_strftime(self, format_str)
             # copy what datetimemodule.c does to produce a time tuple with standard date
             return _underlying_strftime(format_str, (1900, 1, 1, self.hour, self.minute, self.second, 0, 1, -1))
 
@@ -336,16 +338,16 @@ class datetime(_original_datetime_module.datetime):
             try:
                 s1 = _underlying_datetime_type.strftime(d1, format_str)
             except ImportError:
-                s1 = _underlying_strftime(format_str, datetime.timetuple(d1))
+                s1 = _underlying_strftime(alt_time_funcs.adjust_strftime(d1, format_str), datetime.timetuple(d1))
             try:
                 s2 = _underlying_datetime_type.strftime(d2, format_str)
             except ImportError:
-                s2 = _underlying_strftime(format_str, datetime.timetuple(d2))
+                s2 = _underlying_strftime(alt_time_funcs.adjust_strftime(d2, format_str), datetime.timetuple(d2))
             return _repair_year(s1, s2, year, year+400, self.year)
         try:
             return _underlying_datetime_type.strftime(self, format_str)
         except ImportError:
-            return _underlying_strftime(format_str, datetime.timetuple(self))
+            return _underlying_strftime(alt_time_funcs.adjust_strftime(self, format_str), datetime.timetuple(self))
 
     if _has_pre_1900_bug or _has_pre_1000_bug:
         strftime = _fixed_strftime

--- a/virtualtime/alt_time_funcs.py
+++ b/virtualtime/alt_time_funcs.py
@@ -30,15 +30,15 @@ elif sys.platform.startswith('linux'):
 
     def alt_get_local_datetime():
         t = timeval()
-        if libc.gettimeofday(t, None) == 0:
+        if libc.gettimeofday(ctypes.byref(t), None) == 0:
             return datetime.datetime.fromtimestamp(float(t.seconds) + (t.microseconds / 1000000.), None)
         raise ValueError("Error retrieving time")
 
     def alt_get_utc_datetime():
         t = timeval()
-        if libc.gettimeofday(t, None) == 0:
+        if libc.gettimeofday(ctypes.byref(t), None) == 0:
             libc.tzset()
-            utc_offset = (ctypes.c_int32).in_dll(libc, 'timezone')
+            utc_offset = (ctypes.c_int32).in_dll(libc, 'timezone').value
             return datetime.datetime.fromtimestamp(float(t.seconds) + (t.microseconds / 1000000.) + utc_offset,
                                                    None)
         raise ValueError("Error retrieving time")

--- a/virtualtime/alt_time_funcs.py
+++ b/virtualtime/alt_time_funcs.py
@@ -1,0 +1,51 @@
+"""These functions are fallbacks in case we hit the occasional import lock error in datetime functions, and for tests"""
+
+import sys
+import datetime
+
+if sys.platform.startswith('win'):
+    try:
+        import win32api
+    except ImportError:
+        win32api = None
+
+    def alt_get_local_datetime(tz=None):
+        t = win32api.GetLocalTime()
+        return datetime.datetime(t[0], t[1], t[3], t[4], t[5], t[6], t[7] * 1000, tzinfo=tz)
+
+    def alt_get_utc_datetime():
+        t = win32api.GetSystemTime()
+        return datetime.datetime(t[0], t[1], t[3], t[4], t[5], t[6], t[7] * 1000)
+
+elif sys.platform.startswith('linux'):
+    try:
+        import ctypes
+        libc = ctypes.CDLL("libc.so.6")
+        class timeval(ctypes.Structure):
+            _fields_ = [("seconds", ctypes.c_long),("microseconds", ctypes.c_long)]
+    except (ImportError, OSError):
+        ctypes = None
+        libc = None
+        timeval = None
+
+    def alt_get_local_datetime():
+        t = timeval()
+        if libc.gettimeofday(t, None) == 0:
+            return datetime.datetime.fromtimestamp(float(t.seconds) + (t.microseconds / 1000000.), None)
+        raise ValueError("Error retrieving time")
+
+    def alt_get_utc_datetime():
+        t = timeval()
+        if libc.gettimeofday(t, None) == 0:
+            libc.tzset()
+            utc_offset = (ctypes.c_int32).in_dll(libc, 'timezone')
+            return datetime.datetime.fromtimestamp(float(t.seconds) + (t.microseconds / 1000000.) + utc_offset,
+                                                   None)
+        raise ValueError("Error retrieving time")
+else:
+    def alt_get_local_datetime():
+        raise NotImplementedError()
+
+    def alt_get_utc_datetime():
+        raise NotImplementedError()
+

--- a/virtualtime/test_importlock_thread_issue.py
+++ b/virtualtime/test_importlock_thread_issue.py
@@ -165,7 +165,7 @@ class TestBaseCodeWhenImportLockHeld(TestBaseCodeNoImportLock):
 
 
 class TestVirtualTimeBaseCodeWhenImportLockHeld(TestBaseCodeWhenImportLockHeld):
-    date_cls = virtualtime.datetime_module.date
+    date_cls = virtualtime.date
     datetime_cls = virtualtime.datetime
     time_cls = virtualtime.time
 
@@ -173,9 +173,7 @@ class TestVirtualTimeBaseCodeWhenImportLockHeld(TestBaseCodeWhenImportLockHeld):
 
 
 class TestVirtualTimeVirtualCodeWhenImportLockHeld2(TestVirtualTimeBaseCodeWhenImportLockHeld):
-    date_cls = virtualtime.datetime_module.date
     datetime_cls = virtualtime.virtual_datetime
-    time_cls = virtualtime.time
 
 
 if __name__ == '__main__':

--- a/virtualtime/test_importlock_thread_issue.py
+++ b/virtualtime/test_importlock_thread_issue.py
@@ -167,7 +167,7 @@ class TestBaseCodeWhenImportLockHeld(TestBaseCodeNoImportLock):
 class TestVirtualTimeBaseCodeWhenImportLockHeld(TestBaseCodeWhenImportLockHeld):
     date_cls = virtualtime.date
     datetime_cls = virtualtime.datetime
-    time_cls = virtualtime.time
+    time_cls = virtualtime.time_no_importerror
 
     expect_import_error = False
 

--- a/virtualtime/test_importlock_thread_issue.py
+++ b/virtualtime/test_importlock_thread_issue.py
@@ -164,7 +164,7 @@ class TestBaseCodeWhenImportLockHeld(TestBaseCodeNoImportLock):
         self.background_result = TestBaseCodeNoImportLock.log_function_result(self, target, had_exception)
 
 
-class TestVirtualTimeCodeWhenImportLockHeld(TestBaseCodeWhenImportLockHeld):
+class TestVirtualTimeBaseCodeWhenImportLockHeld(TestBaseCodeWhenImportLockHeld):
     date_cls = virtualtime.datetime_module.date
     datetime_cls = virtualtime.datetime
     time_cls = virtualtime.time
@@ -172,14 +172,10 @@ class TestVirtualTimeCodeWhenImportLockHeld(TestBaseCodeWhenImportLockHeld):
     expect_import_error = False
 
 
-    def setUp(self):
-        TestBaseCodeNoImportLock.setUp(self)
-        virtualtime.patch_datetime_module()
-
-
-    def tearDown(self):
-        virtualtime.unpatch_datetime_module()
-        TestBaseCodeNoImportLock.tearDown(self)
+class TestVirtualTimeVirtualCodeWhenImportLockHeld2(TestVirtualTimeBaseCodeWhenImportLockHeld):
+    date_cls = virtualtime.datetime_module.date
+    datetime_cls = virtualtime.virtual_datetime
+    time_cls = virtualtime.time
 
 
 if __name__ == '__main__':

--- a/virtualtime/test_importlock_thread_issue.py
+++ b/virtualtime/test_importlock_thread_issue.py
@@ -12,6 +12,7 @@ import datetime
 import unittest
 from alt_time_funcs import alt_get_local_datetime, alt_get_utc_datetime
 import virtualtime
+import pytz
 
 def use_cpu(n, symbol, finish_early_event=None):
     a = 3
@@ -90,8 +91,26 @@ class TestBaseCodeNoImportLock(unittest.TestCase):
         self.assertEquals(self.datetime_cls(2020,02,20,20,20,20).strftime('%Y-%m-%d %H:%M:%S'), '2020-02-20 20:20:20')
 
     @check_unsafe_function
+    def test_wrap_strftime_ext_on_datetime(self):
+        # check the datetime-specific extensions to strftime
+        naive_date = self.datetime_cls(2020, 02, 20, 20, 20, 20, 2020)
+        self.assertEquals(naive_date.strftime('%Y-%m-%d %H:%M:%S.%f %z %Z'), '2020-02-20 20:20:20.002020  ')
+        utc_date = self.datetime_cls(2020,02,20,20,20,20,2020, tzinfo=pytz.UTC)
+        self.assertEquals(utc_date.strftime('%Y-%m-%d %H:%M:%S.%f %z %Z'), '2020-02-20 20:20:20.002020 +0000 UTC')
+        bst_date = pytz.timezone('Europe/London').localize(self.datetime_cls(2020, 2, 20, 20, 20, 20, 2020))
+        self.assertEquals(bst_date.strftime('%Y-%m-%d %H:%M:%S.%f %z %Z'), '2020-02-20 20:20:20.002020 +0000 GMT')
+        bdt_date = pytz.timezone('Europe/London').localize(self.datetime_cls(2020, 8, 20, 20, 20, 20, 2020))
+        self.assertEquals(bdt_date.strftime('%Y-%m-%d %H:%M:%S.%f %z %Z'), '2020-08-20 20:20:20.002020 +0100 BST')
+
+    @check_unsafe_function
     def test_wrap_strftime_on_time(self):
         self.assertEquals(self.time_cls(20, 20, 20).strftime('%H:%M:%S'), '20:20:20')
+
+    @check_unsafe_function
+    def test_wrap_strftime_ext_on_time(self):
+        # check the datetime-specific extensions to strftime
+        self.assertEquals(self.time_cls(20, 20, 20).strftime('%H:%M:%S.%f'), '20:20:20.000000')
+        self.assertEquals(self.time_cls(20, 20, 20, 2020).strftime('%H:%M:%S.%f'), '20:20:20.002020')
 
     # the tests for today, now, and utcnow are separate because they can themselves import time as a side-effect
     @check_unsafe_function

--- a/virtualtime/test_importlock_thread_issue.py
+++ b/virtualtime/test_importlock_thread_issue.py
@@ -56,9 +56,9 @@ class TestBaseCodeNoImportLock(unittest.TestCase):
 
     @check_unsafe_function
     def test_wrap_strftime(self):
-        datetime.date(2020, 02, 20).strftime('%Y-%m-%d')
-        datetime.datetime(2020,02,20,20,20,20).strftime('%Y-%m-%d %H:%M:%S')
-        datetime.time(20, 20, 20).strftime('%H:%M:%S')
+        self.assertEquals(datetime.date(2020, 02, 20).strftime('%Y-%m-%d'), '2020-02-20')
+        self.assertEquals(datetime.datetime(2020,02,20,20,20,20).strftime('%Y-%m-%d %H:%M:%S'), '2020-02-20 20:20:20')
+        self.assertEquals(datetime.time(20, 20, 20).strftime('%H:%M:%S'), '20:20:20')
 
     @check_unsafe_function
     def test_time_time(self):
@@ -68,13 +68,19 @@ class TestBaseCodeNoImportLock(unittest.TestCase):
 
     @check_unsafe_function
     def test_build_struct_time(self):
-        datetime.date(2020, 02, 20).timetuple()
-        datetime.datetime(2020, 02, 20, 20, 20, 20).timetuple()
-        datetime.datetime(2020, 02, 20, 20, 20, 20).utctimetuple()
+        self.assertEquals(datetime.date(2020, 02, 20).timetuple(), (2020, 02, 20, 0, 0, 0, 3, 51, -1))
+        self.assertEquals(datetime.datetime(2020, 02, 20, 20, 20, 20).timetuple(), (2020, 02, 20, 20, 20, 20, 3, 51, -1))
+        self.assertEquals(datetime.datetime(2020, 02, 20, 20, 20, 20).utctimetuple(), (2020, 02, 20, 20, 20, 20, 3, 51, 0))
 
     @check_unsafe_function
     def test_datetime_strptime(self):
-        datetime.datetime.strptime('2020-02-20 20:20:20', '%Y-%m-%d %H:%M:%S')
+        d = datetime.datetime.strptime('2020-02-20 20:20:20', '%Y-%m-%d %H:%M:%S')
+        self.assertEquals(d.year, 2020)
+        self.assertEquals(d.month, 02)
+        self.assertEquals(d.day, 20)
+        self.assertEquals(d.hour, 20)
+        self.assertEquals(d.minute, 20)
+        self.assertEquals(d.second, 20)
 
 class TestBaseCodeWhenImportLockHeld(TestBaseCodeNoImportLock):
     def check_function(self, target):

--- a/virtualtime/test_importlock_thread_issue.py
+++ b/virtualtime/test_importlock_thread_issue.py
@@ -191,7 +191,7 @@ class TestBaseCodeWhenImportLockHeld(TestBaseCodeNoImportLock):
 
 
 class TestVirtualTimeBaseCodeWhenImportLockHeld(TestBaseCodeWhenImportLockHeld):
-    date_cls = virtualtime.date
+    date_cls = virtualtime.date_no_importerror
     datetime_cls = virtualtime.datetime
     time_cls = virtualtime.time_no_importerror
 

--- a/virtualtime/test_importlock_thread_issue.py
+++ b/virtualtime/test_importlock_thread_issue.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python
+
+"""This checks what happens when trying to use datetime functions that rely on PyImport_ImportModuleNoBlock("time")
+Normally, this should complete without error. However, we have experienced transient and occasional failures
+There is a test for what happens in a background thread when the import lock is held by the main thread
+"""
+
+import threading
+import imp
+import sys
+import datetime
+import unittest
+
+def use_cpu(n, symbol, finish_early_event=None):
+    a = 3
+    for i in range(n):
+        a = 3 * a
+        if i % 10000 == 0:
+            sys.stdout.write(symbol)
+        if finish_early_event is not None and finish_early_event.is_set():
+            return
+
+def check_unsafe_function(target):
+    def checker(self, *args, **kwargs):
+        self.unsafe_function_delay()
+        try:
+            self.check_function(target, *args, **kwargs)
+            self.unsafe_function_raised(target, False)
+        except Exception as e:
+            self.unsafe_function_raised(target, e)
+    return checker
+
+class TestBaseCodeNoImportLock(unittest.TestCase):
+    def setUp(self):
+        self.previous_time_module = sys.modules.pop('time')
+
+    def tearDown(self):
+        sys.modules['time'] = self.previous_time_module
+
+    def unsafe_function_delay(self):
+        use_cpu(20000, '+')
+        sys.stdout.write('&' if 'time' in sys.modules else '/')
+
+    def unsafe_function_raised(self, target, had_exception):
+        """Used to indicate the result of the function"""
+        if had_exception:
+            sys.stderr.write("Could not run %s.%s: %s\n" % (type(self).__name__, target.func_name, had_exception))
+        else:
+            sys.stdout.write("Ran %s.%s successfully\n" % (type(self).__name__, target.func_name))
+        return had_exception
+
+    def check_function(self, target):
+        sys.stdout.write("Testing %s" % target.func_name)
+        target(self)
+        sys.stdout.write('\n')
+
+    @check_unsafe_function
+    def test_wrap_strftime(self):
+        datetime.date(2020, 02, 20).strftime('%Y-%m-%d')
+        datetime.datetime(2020,02,20,20,20,20).strftime('%Y-%m-%d %H:%M:%S')
+        datetime.time(20, 20, 20).strftime('%H:%M:%S')
+
+    @check_unsafe_function
+    def test_time_time(self):
+        datetime.date.today()
+        datetime.datetime.now()
+        datetime.datetime.utcnow()
+
+    @check_unsafe_function
+    def test_build_struct_time(self):
+        datetime.date(2020, 02, 20).timetuple()
+        datetime.datetime(2020, 02, 20, 20, 20, 20).timetuple()
+        datetime.datetime(2020, 02, 20, 20, 20, 20).utctimetuple()
+
+    @check_unsafe_function
+    def test_datetime_strptime(self):
+        datetime.datetime.strptime('2020-02-20 20:20:20', '%Y-%m-%d %H:%M:%S')
+
+class TestBaseCodeWhenImportLockHeld(TestBaseCodeNoImportLock):
+    def check_function(self, target):
+        print("Testing %s" % target.func_name)
+        complete_event = threading.Event()
+        imp.acquire_lock()
+        try:
+            background_thread = threading.Thread(target=self.expect_import_error, name='background_lock_wanter', args=(target, complete_event))
+            background_thread.start()
+            use_cpu(100000, '.', complete_event)
+        finally:
+            imp.release_lock()
+        sys.stdout.write('\n')
+        background_thread.join(timeout=10)
+        assert self.background_result and isinstance(self.background_result, ImportError)
+
+    def expect_import_error(self, target, complete_event=None):
+        try:
+            target(self)
+            self.unsafe_function_raised(target, False)
+        except Exception as e:
+            self.unsafe_function_raised(target, e)
+        if complete_event:
+            complete_event.set()
+
+    def unsafe_function_raised(self, target, had_exception):
+        self.background_result = TestBaseCodeNoImportLock.unsafe_function_raised(self, target, had_exception)
+
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
Python 2 has an import lock. Some of the `datetime` methods try and do an import of the `time` or `_strptime` module, in order to implement their functionality. They use the `PyImport_ImportModuleNoBlock` method to avoid deadlocking, but can therefore raise an `ImportError` if they cannot obtain the import lock, and the required module is not in `sys.modules`

It seems there is a rare race condition where this condition is triggered, even though the required module is clearly imported.
In order to work around this, I have implemented alternative versions of the `datetime` methods that are called only if the `ImportError` is encountered.

I have added unit tests for each of the functions, verifying that:
* in the normal case they don't raise an `ImportError`
* if the import lock is held, and `time` (or `_strptime`) is not in `sys.modules`, they do raise an `ImportError`. There's an exception for the _strptime import, which doesn't actually raise an error
* if the import lock is held, and our derived classes are used, they don't raise an `ImportError`

Currently we only patch the `datetime` class. However some of these functions are in `date` or `time`. I've added implementations of the `date` class, but these aren't patched automatically - they do, however, demonstrate how to work around the problem

The `datetime.strftime` fallback has an additional helper function to handle `%z`, `%Z` and `%f`, all of which are handled by `datetimemodule.c`'s `wrap_strftime`